### PR TITLE
Release 1.0.1. Bugfixes

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -6,6 +6,7 @@ All notable changes to this project will be docmented in this file.
 
 ### Fixes
 
+- Variables declared inside while loops are now declared as local variables when while loops are rewritten to proc calls. (#29)
 - Fix missing locations in certain expressions being constructed
 - Fix SMT Backend crash with "_" ident (#22)
 - Fix crash on FPU stmt in while loops (#27).

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,0 +1,15 @@
+# Changelog
+
+All notable changes to this project will be docmented in this file.
+
+## [Unreleased]
+
+### Fixes
+
+- Fix spurious type error when assigning from data type destructor (#26).
+
+## [1.0.0] - 2025-06-02
+
+### Added
+
+- Initial release of Raven.

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -8,6 +8,7 @@ All notable changes to this project will be docmented in this file.
 
 ## [1.0.1] - 2025-11-22
 
+- Fixed multiple redundant local variable declarations due to excessive havocing.
 - Variables declared inside while loops are now declared as local variables when while loops are rewritten to proc calls. (#29)
 - Fix missing locations in certain expressions being constructed
 - Fix SMT Backend crash with "_" ident (#22)

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -6,6 +6,7 @@ All notable changes to this project will be docmented in this file.
 
 ### Fixes
 
+- Fix SMT Backend crash with "_" ident (#22)
 - Fix crash on FPU stmt in while loops (#27).
 - Added if_block before making call to while_loop proc.
 - Fix spurious type error when type-checking inherited modules (#25).

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -6,6 +6,7 @@ All notable changes to this project will be docmented in this file.
 
 ### Fixes
 
+- Fix missing locations in certain expressions being constructed
 - Fix SMT Backend crash with "_" ident (#22)
 - Fix crash on FPU stmt in while loops (#27).
 - Added if_block before making call to while_loop proc.

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -6,6 +6,8 @@ All notable changes to this project will be docmented in this file.
 
 ### Fixes
 
+## [1.0.1] - 2025-11-22
+
 - Variables declared inside while loops are now declared as local variables when while loops are rewritten to proc calls. (#29)
 - Fix missing locations in certain expressions being constructed
 - Fix SMT Backend crash with "_" ident (#22)

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -6,6 +6,8 @@ All notable changes to this project will be docmented in this file.
 
 ### Fixes
 
+- Fix crash on FPU stmt in while loops (#27).
+- Added if_block before making call to while_loop proc.
 - Fix spurious type error when type-checking inherited modules (#25).
 - Fix spurious type error when assigning from data type destructor (#26).
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -6,6 +6,7 @@ All notable changes to this project will be docmented in this file.
 
 ### Fixes
 
+- Fix spurious type error when type-checking inherited modules (#25).
 - Fix spurious type error when assigning from data type destructor (#26).
 
 ## [1.0.0] - 2025-06-02

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Raven
-![Version 1.0.0](https://img.shields.io/badge/version-1.0.0-green.svg)
+![Version 1.0.1](https://img.shields.io/badge/version-1.0.1-green.svg)
 [![MIT licensed](https://img.shields.io/badge/license-MIT-blue.svg)](https://raw.githubusercontent.com/nyu-acsys/raven/master/LICENSE)
 [![Builds, tests & co](https://github.com/nyu-acsys/raven/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/nyu-acsys/raven/actions/workflows/ci.yml)
 
@@ -43,13 +43,13 @@ Several examples of Raven programs can be found in the [test](test) folder. The 
 The Raven verifier can be executed on a file `test/concurrent/treiber_stack/treiber_stack_atomics.rav` as follows:
 ```
 $ raven test/concurrent/treiber_stack/treiber_stack_atomics.rav
-Raven version 1.0.0
+Raven version 1.0.1
 Verification successful.
 ```
 Here is a failing example:
 ```
 $ raven test/ci/back-end/fail/fpu_fail.rav
-Raven version 1.0.0
+Raven version 1.0.1
 [Error] File "test/ci/back-end/fail/fpu_fail.rav", line 7, columns 2-14:
 7 |   fpu(x.f, 4);
       ^^^^^^^^^^^^

--- a/lib/ast/astDef.ml
+++ b/lib/ast/astDef.ml
@@ -1629,8 +1629,8 @@ module Stmt = struct
     in
     { stmt_desc = Basic (Call call); stmt_loc = loc }
 
-  let mk_assign ~loc lhs rhs =
-    { stmt_desc = Basic (Assign { assign_lhs = lhs; assign_rhs = rhs; assign_is_init = false }); stmt_loc = loc }
+  let mk_assign ~loc ?(is_init = false) lhs rhs =
+    { stmt_desc = Basic (Assign { assign_lhs = lhs; assign_rhs = rhs; assign_is_init = is_init }); stmt_loc = loc }
 
   let mk_field_write ~loc ref field v =
     { stmt_desc = Basic (FieldWrite {field_write_ref = ref; field_write_field = field; field_write_val = v});

--- a/lib/ast/rewriter.ml
+++ b/lib/ast/rewriter.ml
@@ -961,9 +961,9 @@ module Stmt = struct
               stmt_desc =
                 Basic (Fpu { fpu_ref; fpu_field; fpu_old_val; fpu_new_val });
             }
-        | Havoc qual_iden ->
-            let qual_iden = f qual_iden in
-            return { stmt with stmt_desc = Basic (Havoc qual_iden) }
+        | Havoc hvc ->
+            let havoc_var = f hvc.havoc_var in
+            return { stmt with stmt_desc = Basic (Havoc { hvc with havoc_var }) }
         (* TODO: add remaining *)
         | _ ->
             rewrite_expressions_top

--- a/lib/backend/smtLibAST.ml
+++ b/lib/backend/smtLibAST.ml
@@ -86,7 +86,10 @@ let pr_smt_ident ppf id =
     | x -> x
   ) in
 
-  let sanitized_ident = QualIdent.sanitize smt_ident_sanitize_map id in
+  let sanitized_ident = 
+    if QualIdent.(id = QualIdent.from_ident (Ident.make Loc.dummy "_" 0)) then 
+      QualIdent.from_ident (Ident.make Loc.dummy "_0" 0) 
+    else QualIdent.sanitize smt_ident_sanitize_map id in
 
   (* Logs.debug (fun m -> m 
     "smtLibAST.pr_smt_ident: 

--- a/lib/config/config.ml
+++ b/lib/config/config.ml
@@ -1,7 +1,7 @@
 (** Configuration and command line options *)
 
 (** Version string *)
-let version = "1.0.0"
+let version = "1.0.1"
 
 (** The command line options *)
 let cmd_options_spec = []

--- a/lib/frontend/parser.mly
+++ b/lib/frontend/parser.mly
@@ -482,7 +482,7 @@ stmt_wo_trailing_substmt:
 }
 (* havoc *)
 | HAVOC; id = qual_ident; SEMICOLON { 
-  [Stmt.(Basic (Havoc (Expr.to_qual_ident id)))]
+  [Stmt.(Basic (Havoc { havoc_var = (Expr.to_qual_ident id); havoc_is_init = false; } ))]
 }
 
 (* assume / assert / inhale / exhale *)

--- a/lib/frontend/parser_ext.mly
+++ b/lib/frontend/parser_ext.mly
@@ -52,7 +52,7 @@ atomicExt:
         | true ->
             Stmt.(Basic (StmtExt (AtomicInbuiltInit Xchg, args))), Some (xchg_new_val)
         | false ->
-            Stmt.(Basic (StmtExt (AtomicInbuiltNonInit Faa, args))), Some (xchg_new_val)
+            Stmt.(Basic (StmtExt (AtomicInbuiltNonInit Xchg, args))), Some (xchg_new_val)
         end
     | e :: _, _ -> Error.syntax_error (Expr.to_loc e) "Expected single field location or local variables on left-hand side of faa"
     | [], _ -> assert false

--- a/lib/frontend/rewrites/atomicityAnalysis.ml
+++ b/lib/frontend/rewrites/atomicityAnalysis.ml
@@ -195,7 +195,7 @@ let rewrite_au_cmnds (stmt : Stmt.t) : (Stmt.t, atomicity_check) Rewriter.t_ext
         let atomicity_state = take_atomic_step ~loc atomicity_state in
         let* _ = Rewriter.set_user_state atomicity_state in
         Rewriter.return stmt
-    | Basic (Havoc qual_iden) ->
+    | Basic (Havoc hvc) ->
         Rewriter.return stmt
     | Basic (Call call_desc) ->
         let* symbol = Rewriter.find_and_reify call_desc.call_name in

--- a/lib/frontend/rewrites/heapsExplicitTrnsl.ml
+++ b/lib/frontend/rewrites/heapsExplicitTrnsl.ml
@@ -3538,14 +3538,10 @@ module TrnslExhale = struct
                 let* preconds, postconds, optn_args =
                   match Map.find witness_args_conds_exprs_map var_decl.var_name with
                   | None | Some [] ->
-                      let error =
-                        ( Error.Verification,
-                          Expr.to_loc expr,
-                          "No witnesses could be computed for: "
-                          ^ Ident.to_string var_decl.var_name )
-                      in
-                      Logs.warn (fun m -> m "%s" (Error.to_string error));
-                      Rewriter.return ([], [], [])
+                    Logs.warn (fun m -> m "%s%s" 
+                      (Loc.to_string (Expr.to_loc expr)) 
+                      ("No witnesses could be computed for: " ^ Ident.to_string var_decl.var_name));
+                    Rewriter.return ([], [], [])
                   | Some witness_arg_exprs ->
                       let witness_arg_exprs = 
                         let universal_wtns = List.filter witness_arg_exprs ~f:(fun (vd, conds, expr) -> List.is_empty conds) in

--- a/lib/frontend/rewrites/heapsExplicitTrnsl.ml
+++ b/lib/frontend/rewrites/heapsExplicitTrnsl.ml
@@ -5211,7 +5211,7 @@ let rec rewrite_make_heaps_explicit (s : Stmt.t) : Stmt.t Rewriter.t =
             in
 
             let assign_stmt =
-              Stmt.mk_assign ~loc:s.stmt_loc
+              Stmt.mk_assign ~loc:s.stmt_loc ~is_init:fr_desc.field_read_is_init
                 [ fr_desc.field_read_lhs ]
                 (Expr.mk_app ~typ:lhs_var.var_type (DataDestr field_val_destr)
                    [ Expr.mk_maplookup field_heap_expr fr_desc.field_read_ref ])

--- a/lib/frontend/rewrites/rewrites.ml
+++ b/lib/frontend/rewrites/rewrites.ml
@@ -774,9 +774,14 @@ let rec rewrite_loops (stmt : Stmt.t) : Stmt.t Rewriter.t =
               Expr.from_var_decl var_decl)
         in
 
-        Stmt.mk_call ~loc ~lhs:lhs_list
+        (* Stmt.mk_call ~loc ~lhs:lhs_list
           (QualIdent.from_ident loop_proc_name)
-          args_list ~is_spawn:false
+          args_list ~is_spawn:false *)
+
+        Stmt.mk_cond ~loc (Some loop.loop_test) 
+          (Stmt.mk_call ~loc ~lhs:lhs_list
+            (QualIdent.from_ident loop_proc_name) args_list ~is_spawn:false
+          ) (Stmt.mk_skip ~loc)
       in
 
       Logs.debug (fun m -> m "Loop new_stmt:\n %a" Stmt.pr new_stmt);

--- a/lib/frontend/typing.ml
+++ b/lib/frontend/typing.ml
@@ -1160,7 +1160,7 @@ module ProcessCallable = struct
           (VarDef { var_decl; var_init = None })
       in
       let var = QualIdent.from_ident var_decl.var_name in
-      Rewriter.return @@ (Stmt.Havoc var, disam_tbl')
+      Rewriter.return @@ (Stmt.Havoc { havoc_var = var; havoc_is_init = true }, disam_tbl')
     | Spec (sk, spec) ->
       let+ spec = process_stmt_spec disam_tbl spec in
       (Stmt.Spec (sk, spec), disam_tbl)
@@ -1401,9 +1401,9 @@ module ProcessCallable = struct
             }
         in
         (Stmt.AtomicInbuilt ais_desc, disam_tbl)
-    | Havoc qual_ident ->
-      let+ qual_ident, _ = get_assign_lhs qual_ident ~is_init:false in
-      Stmt.Havoc qual_ident, disam_tbl
+    | Havoc hvc ->
+      let+ havoc_var, _ = get_assign_lhs hvc.havoc_var ~is_init:hvc.havoc_is_init in
+      Stmt.Havoc { hvc with havoc_var }, disam_tbl
     | Return expr ->
       if is_ghost_scope && Poly.(call_decl.Callable.call_decl_kind = Proc) then
         Error.type_error stmt_loc "Cannot return in a ghost block";

--- a/lib/frontend/typing.ml
+++ b/lib/frontend/typing.ml
@@ -23,7 +23,7 @@ let tuple_arg_mismatch_error loc expected =
 
 let module_arg_mismatch_error loc typ_constr expected =
   Error.type_error loc
-    (Printf.sprintf "Module %s expects %s." (Type.to_name typ_constr)
+    (Printf.sprintf "Module %s expects %s" (Type.to_name typ_constr)
        (arguments_to_string expected))
 
 let unexpected_functor_error loc =
@@ -55,7 +55,7 @@ module ProcessTypeExpr = struct
                 in
                 App (Var rep_fully_qualified_qual_ident, [], tp_attr))
         | ModInst _ -> unexpected_functor_error tp_attr.type_loc
-        | _ -> Error.type_error tp_attr.type_loc "Expected type identifier.")
+        | _ -> Error.type_error tp_attr.type_loc "Expected type identifier")
     | App (Var _, _, tp_attr) -> unexpected_functor_error tp_attr.type_loc
     | App ((Fld as constr), tp_list, tp_attr) -> (
         match tp_list with
@@ -1978,7 +1978,7 @@ module ProcessModule = struct
                 Error.type_error loc
                   (Printf.sprintf
                      !"%s %{Ident} was already defined in interface \
-                       %{QualIdent}. It cannot be redefined."
+                       %{QualIdent}. It cannot be redefined"
                      (Symbol.kind symbol |> String.capitalize)
                      ident interface_ident)
             | _ -> Rewriter.return ())
@@ -1999,7 +1999,7 @@ module ProcessModule = struct
                   (Printf.sprintf
                      !"Formal parameter %{Ident} of %s %{Ident} does not match \
                        parameter %{Ident} of %{Ident} in interface \
-                       %{QualIdent}."
+                       %{QualIdent}"
                      var_decl.var_name (Symbol.kind symbol) ident
                      ovar_decl.var_name ident interface_ident)
               else
@@ -2013,7 +2013,7 @@ module ProcessModule = struct
               Error.type_error loc
                 (Printf.sprintf
                    !"%s %{Ident} does not have the same number of parameters \
-                     as %{Ident} in interface %{QualIdent}."
+                     as %{Ident} in interface %{QualIdent}"
                    (Symbol.kind symbol) ident ident interface_ident)
         in
 
@@ -2024,7 +2024,7 @@ module ProcessModule = struct
         then
           Error.type_error loc
             (Printf.sprintf
-               !"Cannot redeclare %s %{Ident} from %{QualIdent} as %s."
+               !"Cannot redeclare %s %{Ident} from %{QualIdent} as %s"
                (Symbol.kind orig_symbol) ident interface_ident
                (Symbol.kind symbol))
         else
@@ -2048,7 +2048,7 @@ module ProcessModule = struct
               Error.type_error loc
                 (Printf.sprintf
                    !"%s %{Ident} does not have the same precondition as \
-                     %{Ident} in interface %{QualIdent}."
+                     %{Ident} in interface %{QualIdent}"
                    (Symbol.kind symbol) ident ident interface_ident)
           in
           let* sm =
@@ -2073,7 +2073,7 @@ module ProcessModule = struct
               Error.type_error loc
                 (Printf.sprintf
                    !"%s %{Ident} does not have the same postcondition as \
-                     %{Ident} in interface %{QualIdent}."
+                     %{Ident} in interface %{QualIdent}"
                    (Symbol.kind symbol) ident ident interface_ident)
           in
           match (call_def.call_def, orig_call_def.call_def) with
@@ -2083,7 +2083,7 @@ module ProcessModule = struct
               Error.type_error loc
                 (Printf.sprintf
                    !"%s %{Ident} was already defined in interface \
-                     %{QualIdent}. It cannot be redefined."
+                     %{QualIdent}. It cannot be redefined"
                    (Symbol.kind symbol |> String.capitalize)
                    ident interface_ident)
           | ProcDef { proc_body = None; _ }, ProcDef { proc_body = Some _; _ }
@@ -2142,7 +2142,7 @@ module ProcessModule = struct
           if not @@ List.is_empty mod_def.mod_decl.mod_decl_formals then
             Error.type_error loc
               (Printf.sprintf
-                 !"%s %{Ident} cannot have module parameters."
+                 !"%s %{Ident} cannot have module parameters"
                  (Symbol.kind symbol |> String.capitalize)
                  ident)
           else
@@ -2151,7 +2151,7 @@ module ProcessModule = struct
                 Error.type_error loc
                   (Printf.sprintf
                      !"%s %{Ident} was already defined in interface \
-                       %{QualIdent}. It cannot be redefined."
+                       %{QualIdent}. It cannot be redefined"
                      (Symbol.kind symbol |> String.capitalize)
                      ident interface_ident)
             | _ -> Rewriter.return ())
@@ -2190,7 +2190,7 @@ module ProcessModule = struct
               Error.type_error loc
                 (Printf.sprintf
                    !"%s %{Ident} was already defined in interface \
-                     %{QualIdent}. It cannot be redefined."
+                     %{QualIdent}. It cannot be redefined"
                    (Symbol.kind symbol |> String.capitalize)
                    ident interface_ident)
           | None, Some _ ->
@@ -2201,17 +2201,20 @@ module ProcessModule = struct
                    (Symbol.kind symbol |> String.capitalize)
                    ident interface_ident)
           | _ -> Rewriter.return ())
-    | ModDef _mod_def, ModDef _orig_mod_def ->
+    | ModDef mod_def, ModDef _orig_mod_def ->
+      (* If LHS is free, then we are checking an inherited module against itself, which is OK. *)
+      if mod_def.mod_decl.mod_decl_is_free then Rewriter.return () else
+      (* Otherwise, RHS is being redefined, which is not OK. *)
         Error.type_error loc
           (Printf.sprintf
              !"%s %{Ident} was already defined in interface %{QualIdent}. It \
-               cannot be redefined."
+               cannot be redefined"
              (Symbol.kind symbol |> String.capitalize)
              ident interface_ident)
     | _ ->
         Error.type_error loc
           (Printf.sprintf
-             !"Cannot redeclare %s %{Ident} from interface %{QualIdent} as %s."
+             !"Cannot redeclare %s %{Ident} from interface %{QualIdent} as %s"
              (Symbol.kind orig_symbol) ident interface_ident
              (Symbol.kind symbol))
 
@@ -2237,7 +2240,7 @@ module ProcessModule = struct
       Error.type_error
         (QualIdent.to_loc mod_ident)
         (Printf.sprintf
-           !"%s %{QualIdent} does not implement interface %{QualIdent}."
+           !"%s %{QualIdent} does not implement interface %{QualIdent}"
            (Symbol.kind (Rewriter.Symbol.orig_symbol mod_symbol) |> String.capitalize)
            mod_ident int_ident)
 
@@ -2432,6 +2435,7 @@ module ProcessModule = struct
                     else call
                   in
                   annotate_error_msg (CallDef call)
+                | ModDef mod_def -> ModDef (Module.set_free mod_def)
                 | _ -> annotate_error_msg parent_symbol
               in
               
@@ -2604,7 +2608,7 @@ module ProcessModule = struct
             let ident = Symbol.to_name symbol in
             Map.find symbols_to_check ident
             |> Rewriter.Option.iter ~f:(fun orig_symbol ->
-                   check_implements_symbol interface_ident symbol orig_symbol)
+                check_implements_symbol interface_ident symbol orig_symbol)
         | _ -> Rewriter.return ())
     in
 
@@ -2630,7 +2634,7 @@ module ProcessModule = struct
                   Error.type_error mod_decl.mod_decl_loc
                     (Printf.sprintf
                        !"Module %{Ident} must be declared as an interface. The \
-                         %s %{Ident} is still abstract."
+                         %s %{Ident} is still abstract"
                        mod_decl.mod_decl_name (Symbol.kind symbol)
                        (Symbol.to_name symbol))
               | _ -> ()))

--- a/test/arrays/array.rav
+++ b/test/arrays/array.rav
@@ -63,7 +63,7 @@ interface Array[E: Library.Type] {
   func inverse(m: Map[Int, E], i: Int, j: Int, k: E) returns (res: Int)
 
   auto lemma invertable()
-    ensures forall m: Map[Int, E], i: Int, j: Int, i1: Int :: {m[i1]} 
+    ensures forall m: Map[Int, E], i: Int, j: Int, i1: Int :: {inverse(m, i, j, m[i1])} 
       injective(m, i, j) && i <= i1 < j ==> inverse(m, i, j, m[i1]) == i1
 
   auto lemma invertable2()

--- a/test/arrays/array_utils.rav
+++ b/test/arrays/array_utils.rav
@@ -37,7 +37,7 @@ interface Array[E: Library.Type] {
   func inverse(m: Map[Int, E], i: Int, j: Int, k: E) returns (res: Int)
 
   auto lemma invertable()
-    ensures forall m: Map[Int, E], i: Int, j: Int, i1: Int :: {m[i1]} 
+    ensures forall m: Map[Int, E], i: Int, j: Int, i1: Int :: {inverse(m, i, j, m[i1])} 
       injective(m, i, j) && i <= i1 < j ==> inverse(m, i, j, m[i1]) == i1
 
   auto lemma invertable2()

--- a/test/arrays/array_utils.t
+++ b/test/arrays/array_utils.t
@@ -1,0 +1,2 @@
+  $ dune exec -- raven --shh ./array_utils.rav
+  Verification successful.

--- a/test/arrays/dune
+++ b/test/arrays/dune
@@ -2,7 +2,5 @@
  (deps
   %{project_root}/bin/raven.exe
   %{project_root}/lib/library/resource_algebra.rav
-  ; Include the arrays directory
-  (source_tree %{project_root}/test/arrays)
   (:rav
    (glob_files_rec *.rav))))

--- a/test/ci/back-end/atomic_spec/treiber_stack_atomics.t
+++ b/test/ci/back-end/atomic_spec/treiber_stack_atomics.t
@@ -1,6 +1,6 @@
   $ dune exec -- raven --shh ./treiber_stack_atomics.rav
-  [Warning] File "./treiber_stack_atomics.rav", line 18, columns 21-134:
+  [Warning] File "./treiber_stack_atomics.rav", line 18, columns 20-135:
   18 |     (xs != nil() && (exists tl0: Ref, q:Real ::  q > 0.0 && (own(hd.value, xs.elem, q) && own(hd.next, tl0, q) && is_list(tl0, xs.tl))))
-                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  Verification Error: No witnesses could be computed for: q.
+                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  No witnesses could be computed for: q
   Verification successful.

--- a/test/ci/back-end/while_loop_cond.rav
+++ b/test/ci/back-end/while_loop_cond.rav
@@ -1,0 +1,15 @@
+module Fink = Library.Frac[Library.IntType];
+ghost field plink: Fink;
+
+proc unghosting(b: Bool, x: Ref) 
+  requires own(x, plink, Fink.frac_chunk(10, 1.0)) 
+{
+  while (!b)
+    invariant b ? 
+      own(x, plink, Fink.frac_chunk(11, 1.0)) : 
+      own(x, plink, Fink.frac_chunk(10, 1.0)) 
+  {
+    fpu(x, plink, Fink.frac_chunk(11, 1.0));
+    b := true;
+  }
+}

--- a/test/ci/back-end/while_loop_cond.t
+++ b/test/ci/back-end/while_loop_cond.t
@@ -1,0 +1,2 @@
+  $ dune exec -- raven --shh ./while_loop_cond.rav
+  Verification successful.

--- a/test/ci/back-end/while_loop_fpu_fail.rav
+++ b/test/ci/back-end/while_loop_fpu_fail.rav
@@ -1,0 +1,13 @@
+module Fink = Library.Frac[Library.IntType];
+ghost field plink: Fink;
+
+proc unghosting(b: Bool, x: Ref) 
+  requires own(x, plink, Fink.frac_chunk(10, 1.0)) 
+{
+  while (!b)
+    invariant own(x, plink, Fink.frac_chunk(10, 1.0)) 
+  {
+    fpu(x, plink, Fink.frac_chunk(11, 1.0));
+    b := true;
+  }
+}

--- a/test/ci/back-end/while_loop_fpu_fail.t
+++ b/test/ci/back-end/while_loop_fpu_fail.t
@@ -1,0 +1,14 @@
+  $ dune exec -- raven --shh ./while_loop_fpu_fail.rav
+  [Error] File "./while_loop_fpu_fail.rav", line 8, columns 14-53:
+  8 |     invariant own(x, plink, Fink.frac_chunk(10, 1.0)) 
+                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  Verification Error: This loop invariant may not be maintained.
+  [Error] File "./while_loop_fpu_fail.rav", line 8, columns 14-53:
+  8 |     invariant own(x, plink, Fink.frac_chunk(10, 1.0)) 
+                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  Verification Error: This loop invariant may not be maintained.
+  [Error] File "./while_loop_fpu_fail.rav", line 8, columns 14-53:
+  8 |     invariant own(x, plink, Fink.frac_chunk(10, 1.0)) 
+                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  Related Location: This own predicate may not hold.
+  [1]

--- a/test/ci/front-end/datatype_destr_quant.rav
+++ b/test/ci/front-end/datatype_destr_quant.rav
@@ -1,0 +1,13 @@
+module M {
+  rep type T = data {
+    case unit();
+    case twonit(head: Ref)
+  }
+  field f: T;
+}
+
+proc p() returns (ret: Ref) requires true ensures true {
+  var r: Ref := new(M.f: M.unit);
+  var m: M := M.twonit(r);
+  ret := m.M.head;
+}

--- a/test/ci/front-end/datatype_destr_quant.t
+++ b/test/ci/front-end/datatype_destr_quant.t
@@ -1,0 +1,2 @@
+  $ dune exec -- raven --shh ./datatype_destr_quant.rav
+  Verification successful.

--- a/test/ci/front-end/ssa_init_decls.rav
+++ b/test/ci/front-end/ssa_init_decls.rav
@@ -1,0 +1,16 @@
+field f: Int
+
+proc q() returns (ret: Int) 
+    ensures ret == 1
+{
+    return 1;
+}
+
+proc p(z: Ref)
+    requires own(z, f, 1, 1.0)
+{
+
+    var x: Int := z.f;
+    x := q();
+    var y := q();
+}

--- a/test/ci/front-end/ssa_init_decls.t
+++ b/test/ci/front-end/ssa_init_decls.t
@@ -1,0 +1,2 @@
+  $ dune exec -- raven --shh ./ssa_init_decls.rav
+  Verification successful.

--- a/test/ci/front-end/while_loop_fpu.rav
+++ b/test/ci/front-end/while_loop_fpu.rav
@@ -1,0 +1,25 @@
+module Fink = Library.Frac[Library.IntType];
+ghost field plink: Fink;
+
+module T { 
+  ghost field blink: Library.Fraction;
+  val frac_val1: Library.Fraction := Library.Fraction.frac(1.0);
+  val frac_val2: Library.Fraction := Library.Fraction.frac(0.5);
+}
+
+proc unghosting(b: Bool, x: Ref) 
+  requires own(x, plink, Fink.frac_chunk(10, 1.0)) 
+  requires own(x, T.blink, T.frac_val1)
+{
+  while (!b || !b)
+    invariant own(x, plink, Fink.frac_chunk(10, 1.0)) 
+            && own(x, T.blink, T.frac_val2)
+  {
+    var frac_val3: Library.Fraction := T.frac_val2;
+
+    fpu(x, plink, Fink.frac_chunk(10, 1.0));
+    fpu(x, T.blink, T.frac_val2);
+    fpu(x, T.blink, frac_val3);
+    b := true;
+  }
+}

--- a/test/ci/front-end/while_loop_fpu.t
+++ b/test/ci/front-end/while_loop_fpu.t
@@ -1,0 +1,2 @@
+  $ dune exec -- raven --shh ./while_loop_fpu.rav
+  Verification successful.

--- a/test/ci/front-end/while_loop_locals.rav
+++ b/test/ci/front-end/while_loop_locals.rav
@@ -1,0 +1,13 @@
+field f: Int
+
+proc p() {
+    var z: Ref := new(f: 1);
+    while(true)
+        invariant own(z, f, 1, 1.0)
+    {
+        val p := true;
+        var x: Bool;
+        x := true;
+        var y := z.f;
+    }
+}

--- a/test/ci/front-end/while_loop_locals.t
+++ b/test/ci/front-end/while_loop_locals.t
@@ -1,0 +1,2 @@
+  $ dune exec -- raven --shh ./while_loop_locals.rav
+  Verification successful.

--- a/test/comparison/adt_buggy.t
+++ b/test/comparison/adt_buggy.t
@@ -1,0 +1,6 @@
+  $ dune exec -- raven --shh ./adt_buggy.rav
+  [Error] File "./adt_buggy.rav", line 75, column 11 to line 80, column 13:
+  75 |     assert !is_nil(xs)
+                  ^^^^^^^^^^^
+  Verification Error: This assertion may be violated.
+  [1]

--- a/test/comparison/adt_correct.t
+++ b/test/comparison/adt_correct.t
@@ -1,0 +1,2 @@
+  $ dune exec -- raven --shh ./adt_correct.rav
+  Verification successful.

--- a/test/comparison/arc_buggy.t
+++ b/test/comparison/arc_buggy.t
@@ -1,0 +1,10 @@
+  $ dune exec -- raven --shh ./arc_buggy.rav
+  [Error] File "./arc_buggy.rav", line 131, columns 12-27:
+  131 |             fold arcInv(x);
+                    ^^^^^^^^^^^^^^^
+  Verification Error: Failed to fold predicate. The body of the predicate may not hold at this point.
+  [Error] File "./arc_buggy.rav", line 23, columns 49-67:
+  23 |         exists v: Int :: (v <= 0 ? noTokens(x) : tokenCounter(x, v)) && own(x.c, v, 1.0)
+                                                        ^^^^^^^^^^^^^^^^^^
+  Related Location: This predicate may not hold.
+  [1]

--- a/test/comparison/barrier.t
+++ b/test/comparison/barrier.t
@@ -1,0 +1,2 @@
+  $ dune exec -- raven --shh ./barrier.rav
+  Verification successful.

--- a/test/comparison/barrier_buggy.t
+++ b/test/comparison/barrier_buggy.t
@@ -1,0 +1,10 @@
+  $ dune exec -- raven --shh ./barrier_buggy.rav
+  [Error] File "./barrier_buggy.rav", line 284, columns 12-34:
+  284 |             fold is_barrier(l, r);
+                    ^^^^^^^^^^^^^^^^^^^^^^
+  Verification Error: Failed to fold predicate. The body of the predicate may not hold at this point.
+  [Error] File "./barrier_buggy.rav", line 109, columns 12-25:
+  109 |             own(l.ctr, z)
+                    ^^^^^^^^^^^^^
+  Related Location: This own predicate may not hold.
+  [1]

--- a/test/comparison/barrier_client.t
+++ b/test/comparison/barrier_client.t
@@ -1,0 +1,2 @@
+  $ dune exec -- raven --shh ./barrier_client.rav
+  Verification successful.

--- a/test/comparison/bounded_counter.t
+++ b/test/comparison/bounded_counter.t
@@ -1,0 +1,2 @@
+  $ dune exec -- raven --shh ./bounded_counter.rav
+  Verification successful.

--- a/test/comparison/cas_counter.t
+++ b/test/comparison/cas_counter.t
@@ -1,0 +1,2 @@
+  $ dune exec -- raven --shh ./cas_counter.rav
+  Verification successful.

--- a/test/comparison/cas_counter_client.t
+++ b/test/comparison/cas_counter_client.t
@@ -1,0 +1,2 @@
+  $ dune exec -- raven --shh ./cas_counter_client.rav
+  Verification successful.

--- a/test/comparison/dune
+++ b/test/comparison/dune
@@ -2,5 +2,7 @@
  (deps
   %{project_root}/bin/raven.exe
   %{project_root}/lib/library/resource_algebra.rav
+  ; Include the concurrent directory
+  (source_tree %{project_root}/test/concurrent)
   (:rav
    (glob_files_rec *.rav))))

--- a/test/comparison/fork_join.t
+++ b/test/comparison/fork_join.t
@@ -1,0 +1,2 @@
+  $ dune exec -- raven --shh ./fork_join.rav
+  Verification successful.

--- a/test/comparison/fork_join_client.t
+++ b/test/comparison/fork_join_client.t
@@ -1,0 +1,2 @@
+  $ dune exec -- raven --shh ./fork_join_client.rav
+  Verification successful.

--- a/test/comparison/inc_dec.t
+++ b/test/comparison/inc_dec.t
@@ -1,0 +1,2 @@
+  $ dune exec -- raven --shh ./inc_dec.rav
+  Verification successful.

--- a/test/comparison/lclist.t
+++ b/test/comparison/lclist.t
@@ -1,0 +1,2 @@
+  $ dune exec -- raven --shh ./lclist.rav
+  Verification successful.

--- a/test/comparison/lclist_buggy.t
+++ b/test/comparison/lclist_buggy.t
@@ -1,0 +1,10 @@
+  $ dune exec -- raven --shh ./lclist_buggy.rav
+  [Error] File "./lclist_buggy.rav", line 145, columns 16-57:
+  145 |                 fold resource((p, vp))[nx := n, vx := k];
+                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  Verification Error: Failed to fold predicate. The body of the predicate may not hold at this point.
+  [Error] File "./lclist_buggy.rav", line 20, columns 16-35:
+  20 |                 own((r#0).next, nx) 
+                       ^^^^^^^^^^^^^^^^^^^
+  Related Location: This own predicate may not hold.
+  [1]

--- a/test/comparison/msc_queue.t
+++ b/test/comparison/msc_queue.t
@@ -1,0 +1,2 @@
+  $ dune exec -- raven --shh ./msc_queue.rav
+  Verification successful.

--- a/test/comparison/peterson.t
+++ b/test/comparison/peterson.t
@@ -1,0 +1,2 @@
+  $ dune exec -- raven --shh ./peterson.rav
+  Verification successful.

--- a/test/comparison/peterson_buggy.t
+++ b/test/comparison/peterson_buggy.t
@@ -1,0 +1,10 @@
+  $ dune exec -- raven --shh ./peterson_buggy.rav
+  [Error] File "./peterson_buggy.rav", line 207, column 8 to line 213, column 10:
+  207 |         fold peterson_inv(l, r)[
+                ^^^^^^^^^^^^^^^^^^^^^^^^
+  Verification Error: Failed to fold predicate. The body of the predicate may not hold at this point.
+  [Error] File "./peterson_buggy.rav", line 25, columns 12-37:
+  25 |             own(l.wait_left, wl, 0.5)
+                   ^^^^^^^^^^^^^^^^^^^^^^^^^
+  Related Location: This own predicate may not hold.
+  [1]

--- a/test/comparison/queue.t
+++ b/test/comparison/queue.t
@@ -1,0 +1,2 @@
+  $ dune exec -- raven --shh ./queue.rav
+  Verification successful.

--- a/test/comparison/rwlock_duolock_buggy.t
+++ b/test/comparison/rwlock_duolock_buggy.t
@@ -1,0 +1,10 @@
+  $ dune exec -- raven --shh ./rwlock_duolock_buggy.rav
+  [Error] File "./rwlock_duolock_buggy.rav", line 122, columns 4-44:
+  122 |     fold LkBResource.resource((l, lkA_ref));
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  Verification Error: Failed to fold predicate. The body of the predicate may not hold at this point.
+  [Error] File "./rwlock_duolock_buggy.rav", line 34, columns 14-34:
+  34 |               tokenCounter(r#0, z) && LkA.locked(r#1)
+                     ^^^^^^^^^^^^^^^^^^^^
+  Related Location: This predicate may not hold.
+  [1]

--- a/test/comparison/rwlock_lockless_faa.t
+++ b/test/comparison/rwlock_lockless_faa.t
@@ -1,0 +1,2 @@
+  $ dune exec -- raven --shh ./rwlock_lockless_faa.rav
+  Verification successful.

--- a/test/comparison/rwlock_ticket_bounded.t
+++ b/test/comparison/rwlock_ticket_bounded.t
@@ -1,0 +1,2 @@
+  $ dune exec -- raven --shh ./rwlock_ticket_bounded.rav
+  Verification successful.

--- a/test/comparison/rwlock_ticket_unbounded.t
+++ b/test/comparison/rwlock_ticket_unbounded.t
@@ -1,0 +1,2 @@
+  $ dune exec -- raven --shh ./rwlock_ticket_unbounded.rav
+  Verification successful.

--- a/test/comparison/ticket_lock_client.t
+++ b/test/comparison/ticket_lock_client.t
@@ -1,0 +1,2 @@
+  $ dune exec -- raven --shh ./ticket_lock_client.rav
+  Verification successful.

--- a/test/comparison/tokens.t
+++ b/test/comparison/tokens.t
@@ -1,0 +1,2 @@
+  $ dune exec -- raven --shh ./tokens.rav
+  Verification successful.

--- a/test/concurrent/lock/clh-lock.t
+++ b/test/concurrent/lock/clh-lock.t
@@ -1,0 +1,6 @@
+  $ dune exec -- raven --shh ./clh-lock.rav
+  [Warning] File "./clh-lock.rav", line 51, columns 4-44:
+  51 |     fold queued_loc(newloc)[b_disj := true];
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  No witnesses could be computed for: b^200
+  Verification successful.

--- a/test/concurrent/lock/mcs-lock.t
+++ b/test/concurrent/lock/mcs-lock.t
@@ -1,0 +1,2 @@
+  $ dune exec -- raven --shh ./mcs-lock.rav
+  Verification successful.

--- a/test/concurrent/lock/spin-lock_compact.t
+++ b/test/concurrent/lock/spin-lock_compact.t
@@ -1,0 +1,2 @@
+  $ dune exec -- raven --shh ./spin-lock_compact.rav
+  Verification successful.

--- a/test/concurrent/lock/ticket-lock.t
+++ b/test/concurrent/lock/ticket-lock.t
@@ -1,0 +1,2 @@
+  $ dune exec -- raven --shh ./ticket-lock.rav
+  Verification successful.

--- a/test/concurrent/templates/bplustree.t
+++ b/test/concurrent/templates/bplustree.t
@@ -1,0 +1,2 @@
+  $ dune exec -- raven --shh ./bplustree.rav
+  Verification successful.

--- a/test/concurrent/templates/ccm.t
+++ b/test/concurrent/templates/ccm.t
@@ -1,0 +1,2 @@
+  $ dune exec -- raven --shh ./ccm.rav
+  Verification successful.

--- a/test/concurrent/templates/keyset_ra.t
+++ b/test/concurrent/templates/keyset_ra.t
@@ -1,0 +1,2 @@
+  $ dune exec -- raven --shh ./keyset_ra.rav
+  Verification successful.

--- a/test/iterated-star/binary-search.t
+++ b/test/iterated-star/binary-search.t
@@ -1,0 +1,2 @@
+  $ dune exec -- raven --shh ./binary-search.rav
+  Verification successful.

--- a/test/iterated-star/graph_marking_buggy.t
+++ b/test/iterated-star/graph_marking_buggy.t
@@ -1,0 +1,6 @@
+  $ dune exec -- raven --shh ./graph_marking_buggy.rav
+  [Error] File "./graph_marking_buggy.rav", line 111, columns 8-48:
+  111 | 	assert forall n: Ref :: n in nodes ==> mMap2[n];
+                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  Verification Error: This assertion may be violated.
+  [1]

--- a/test/iterated-star/graph_marking_correct.t
+++ b/test/iterated-star/graph_marking_correct.t
@@ -1,0 +1,2 @@
+  $ dune exec -- raven --shh ./graph_marking_correct.rav
+  Verification successful.

--- a/test/rec-preds/tree_delete.t
+++ b/test/rec-preds/tree_delete.t
@@ -1,0 +1,2 @@
+  $ dune exec -- raven --shh ./tree_delete.rav
+  Verification successful.


### PR DESCRIPTION
Raven 1.0.1

- Fixed multiple redundant local variable declarations due to excessive havocing.
- Variables declared inside while loops are now declared as local variables when while loops are rewritten to proc calls. (#29)
- Fix missing locations in certain expressions being constructed
- Fix SMT Backend crash with "_" ident (#22)
- Fix crash on FPU stmt in while loops (#27).
- Added if_block before making call to while_loop proc.
- Fix spurious type error when type-checking inherited modules (#25).
- Fix spurious type error when assigning from data type destructor (#26).