### PR TITLE
Fix release build: strip the staged binary, not dune's read-only artifact

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,16 +78,19 @@ jobs:
 
       - run: opam exec -- dune build bin/raven.exe
 
-      - name: Strip binary
-        if: matrix.os != 'windows-latest'
-        run: strip _build/default/bin/raven.exe
-
-      - name: Stage binary (unix)
+      # Strip the staged copy rather than dune's own artifact: dune leaves everything
+      # under _build read-only, and `strip` needs to write its target (it rewrites via a
+      # temporary copy alongside it), so stripping in place fails with "unable to copy
+      # file ... Permission denied". The copy in dist/ is writable, and is what actually
+      # gets packaged.
+      - name: Stage and strip binary (unix)
         if: matrix.os != 'windows-latest'
         shell: bash
         run: |
           mkdir -p dist
           cp _build/default/bin/raven.exe dist/raven
+          chmod u+w dist/raven
+          strip dist/raven
 
       - name: Stage binary (windows)
         if: matrix.os == 'windows-latest'


### PR DESCRIPTION
The `v1.2.0` release build failed on every Unix target:

```
strip: unable to copy file '_build/default/bin/raven.exe'; reason: Permission denied
```

Dune leaves everything under `_build` read-only, and `strip` rewrites its target through a temporary copy alongside it, so it needs write permission on the file — stripping in place cannot work. Windows was unaffected only because the step is skipped there (`if: matrix.os != 'windows-latest'`).

This isn't a regression from #41. The step has always stripped in place; it worked for `v1.2.0`'s predecessors and has since broken through runner/binutils drift.

Fixes it by stripping the staged copy in `dist/`, which is writable and is what actually gets packaged. That also removes the ordering hazard of mutating a build artifact before copying it.

## Status of the release

`v1.2.0` is tagged at edd22d9 but **no release was published** — the `release` job has `needs: build`, so it never ran and there are no assets. Nothing downstream has seen it.

Once this merges, the tag needs moving to the new tip and re-pushing to retrigger the build. `raven-lang` packaging is still waiting on that release existing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
