### PR TITLE
Build the Intel macOS binary on macos-15-intel

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
             artifact: raven-linux-x64
           - os: ubuntu-24.04-arm
             artifact: raven-linux-arm64
-          - os: macos-13
+          - os: macos-15-intel
             artifact: raven-darwin-x64
           - os: macos-14
             artifact: raven-darwin-arm64


### PR DESCRIPTION
`v1.2.0` could not be released because the `macos-13` job never started.

GitHub has retired the macOS 13 Intel image, so that label no longer schedules — the job sits queued indefinitely rather than failing, and since `release` has `needs: build`, nothing is ever published. Two runs demonstrate it:

| run | age when checked | `macos-13` | other four targets |
|---|---|---|---|
| 30730178761 | ~10.5 h | queued, never started | started within seconds |
| 30750895114 | ~35 min | queued, never started | all passed |

`macos-15-intel` is the current x86_64 macOS image (per [actions/runner-images](https://github.com/actions/runner-images)). The artifact name is unchanged, so `raven-darwin-x64` is still published and `raven-lang`'s packaging matrix — which downloads exactly that asset — is unaffected.

#42's strip fix is confirmed working: in run 30750895114 all three previously-failing Unix builds passed.

## Follow-up, not done here

`macos-14`, used for `raven-darwin-arm64`, now carries a deprecated badge too. It still schedules and passes, so I left it alone rather than perturbing a working target mid-release — but it will need moving to `macos-15` before it goes the same way as `macos-13`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
